### PR TITLE
Change from "API key" to "SDK key" to avoid mixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ is designed to be easy to implement and use.
 ## Requirements
 * iOS 8 or later
 * Xcode 7 (iOS 9 SDK)
-* An iZettle API Key. Visit [iZettle Developer Page](https://www.izettle.com/se/developer) in order to obtain one.
+* An iZettle SDK Key. Visit [iZettle Developer Page](https://www.izettle.com/se/developer) in order to obtain one.
 
 ## Installation
 


### PR DESCRIPTION
Lets not use API when it comes to the iOS SDK to avoid mixup with our HTTP based APIs. This text leads the reader into the wrong path when going to our developer page, making them apply for API credentials instead of an SDK key.