### PR TITLE
Spelling fix: 'Finish' -> 'Finnish'

### DIFF
--- a/iZettleSDK/iZettlePayments.framework/localization/en_GB.json
+++ b/iZettleSDK/iZettlePayments.framework/localization/en_GB.json
@@ -804,7 +804,7 @@
 	"#CreateCashRefundPurchaseCancelButton": "OK",
 	"#ssPrice3": "£3.00",
 	"#ReaderDisplayWaitingForAmount": "Waiting for amount...",
-	"#FinlandFinnish": "Finland (Finish)",
+	"#FinlandFinnish": "Finland (Finnish)",
 	"#PrinterJobTitleReceipt": "Receipt",
 	"#IdPhoto2Description": "Bank statement",
 	"#ReaderInfo": "Card readers",


### PR DESCRIPTION
The language spoken in Finland is called Finnish, not Finish.

Relates to: https://github.com/iZettle/iZettle-iOS/pull/9769