### PR TITLE
The new iZettleTransport.framework is not linked by Cocoapods

### DIFF
--- a/iZettleSDK.podspec
+++ b/iZettleSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'iZettleSDK'
-  s.version      = '2.0'
+  s.version      = '2.0.1'
   s.summary      = 'iZettle SDK for iOS'
   s.description  = <<-DESC
                     For detailed information, please see iZettleSDK documentation and Readme.

--- a/iZettleSDK.podspec
+++ b/iZettleSDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files =  "#{s.name}/**/*.{h,swift}" 
   s.preserve_paths = 'iZettleSDK/iZettleSDK.framework'
   s.public_header_files = 'iZettleSDK/iZettleSDK.framework/**/*.h'
-  s.vendored_frameworks = 'iZettleSDK/iZettleSDK.framework', 'iZettleSDK/iZettleShared.framework', 'iZettleSDK/iZettlePayments.framework'
+  s.vendored_frameworks = 'iZettleSDK/iZettleSDK.framework', 'iZettleSDK/iZettleShared.framework', 'iZettleSDK/iZettlePayments.framework', 'iZettleSDK/iZettleTransport.framework'
   s.frameworks = 'SystemConfiguration', 'CoreLocation', 'ExternalAccessory', 'AudioToolbox', 'AVFoundation', 'MediaPlayer', 'QuartzCore', 'Accelerate', 'MessageUI', 'CoreData'
   s.library   = 'z', 'c++'
   s.xcconfig  =  { 'OTHER_LDFLAGS' => '-ObjC', 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/iZettleSDK"' }


### PR DESCRIPTION
This PR adds `iZettleTransport.framework` to the list of linked frameworks.

Feel free to change the version (2.0.1), but I had to bump it to make my fork work correctly.

Fixes #218 