### PR TITLE
Simplified custom auth example

### DIFF
--- a/Example/Sample/iZettleSDKSample.xcodeproj/project.pbxproj
+++ b/Example/Sample/iZettleSDKSample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9B8B199E24754A0F00C74D78 /* CustomAuthorizationProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B8B199D24754A0F00C74D78 /* CustomAuthorizationProvider.m */; };
 		9BC1DCBB24ACBA58004E74DC /* AccountManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BC1DCBA24ACBA58004E74DC /* AccountManager.m */; };
+		B8F6005F275FA24800DF163D /* AccessTokenFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B8F6005D275FA24800DF163D /* AccessTokenFetcher.m */; };
 		D7E94CE024AE529B00B55A9A /* iZettlePayments.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7E94CD824AE528A00B55A9A /* iZettlePayments.xcframework */; };
 		D7E94CE124AE529B00B55A9A /* iZettlePayments.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D7E94CD824AE528A00B55A9A /* iZettlePayments.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D7E94CE224AE529D00B55A9A /* iZettleSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7E94CDB24AE528B00B55A9A /* iZettleSDK.xcframework */; };
@@ -45,6 +46,8 @@
 		9B8B199D24754A0F00C74D78 /* CustomAuthorizationProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomAuthorizationProvider.m; sourceTree = "<group>"; };
 		9BC1DCB924ACBA58004E74DC /* AccountManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccountManager.h; sourceTree = "<group>"; };
 		9BC1DCBA24ACBA58004E74DC /* AccountManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AccountManager.m; sourceTree = "<group>"; };
+		B8F6005D275FA24800DF163D /* AccessTokenFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccessTokenFetcher.m; sourceTree = "<group>"; };
+		B8F6005E275FA24800DF163D /* AccessTokenFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessTokenFetcher.h; sourceTree = "<group>"; };
 		D7E94CD824AE528A00B55A9A /* iZettlePayments.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = iZettlePayments.xcframework; path = ../../iZettleSDK/iZettlePayments.xcframework; sourceTree = "<group>"; };
 		D7E94CDB24AE528B00B55A9A /* iZettleSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = iZettleSDK.xcframework; path = ../../iZettleSDK/iZettleSDK.xcframework; sourceTree = "<group>"; };
 		E6F9FED91DDDFFC80051C21D /* AmountWheel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AmountWheel.h; sourceTree = "<group>"; };
@@ -93,6 +96,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		B8F6005C275FA24800DF163D /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				B8F6005E275FA24800DF163D /* AccessTokenFetcher.h */,
+				B8F6005D275FA24800DF163D /* AccessTokenFetcher.m */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		D7E94CD724AE527F00B55A9A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -105,6 +117,7 @@
 		E6F9FED81DDDFFC80051C21D /* iZettleSDKSample */ = {
 			isa = PBXGroup;
 			children = (
+				B8F6005C275FA24800DF163D /* Helpers */,
 				E6F9FED91DDDFFC80051C21D /* AmountWheel.h */,
 				E6F9FEDA1DDDFFC80051C21D /* AmountWheel.m */,
 				E6F9FEDB1DDDFFC80051C21D /* AppDelegate.h */,
@@ -202,6 +215,7 @@
 				E6F9FEEB1DDDFFC80051C21D /* AppDelegate.m in Sources */,
 				E6F9FEEA1DDDFFC80051C21D /* AmountWheel.m in Sources */,
 				E6F9FEF21DDDFFC80051C21D /* main.m in Sources */,
+				B8F6005F275FA24800DF163D /* AccessTokenFetcher.m in Sources */,
 				9BC1DCBB24ACBA58004E74DC /* AccountManager.m in Sources */,
 				9B8B199E24754A0F00C74D78 /* CustomAuthorizationProvider.m in Sources */,
 				E6F9FEEF1DDDFFC80051C21D /* ConsoleViewController.m in Sources */,

--- a/Example/Sample/iZettleSDKSample/CustomAuthorizationProvider.m
+++ b/Example/Sample/iZettleSDKSample/CustomAuthorizationProvider.m
@@ -7,47 +7,15 @@
 
 #import "CustomAuthorizationProvider.h"
 #import "AccountManager.h"
-@import CommonCrypto;
-@import SafariServices;
-
-static NSString *baseURL = @"https://oauth.izettle.com";
-
-#pragma mark - UserAccountIdentifier
-
-@interface UserAccountIdentifier: NSObject
-
-@property(nullable, strong, nonatomic, readonly) NSString *email;
-@property(nullable, strong, nonatomic, readonly) NSUUID *uuid;
-
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
-
-@end
-
-@implementation UserAccountIdentifier
-
-- (instancetype)initWithEmail:(NSString *)email {
-    if ([super init]) {
-        _email = email;
-    }
-    return self;
-}
-
-- (instancetype)initWithUUID:(NSUUID *)uuid {
-    if ([super init]) {
-        _uuid = uuid;
-    }
-    return self;
-}
-
-@end
+#import "AccessTokenFetcher.h"
 
 #pragma mark - CustomAuthorizationProvider
 
-@interface CustomAuthorizationProvider()<SFSafariViewControllerDelegate>
+@interface CustomAuthorizationProvider() <iZettleSDKAuthorizationProvider>
 
 @property(nonatomic, readonly)NSString *clientId;
 @property(nonatomic, readonly)NSURL *callback;
+@property(nonatomic)AccessTokenFetcher *tokenFetcher;
 
 @end
 
@@ -59,6 +27,10 @@ static NSString *baseURL = @"https://oauth.izettle.com";
     if (self = [super init]) {
         _clientId = clientId;
         _callback = callback;
+        self.tokenFetcher = [[AccessTokenFetcher alloc] initWith:clientId callbackUrl:callback];
+        self.tokenFetcher.safariViewControllerDidFinish = ^{
+            [CustomAuthorizationProvider notifySFSafariDidFinishWithCallbackURL:nil];
+        };
     }
     return self;
 }
@@ -70,190 +42,19 @@ static NSString *baseURL = @"https://oauth.izettle.com";
     [NSNotificationCenter.defaultCenter postNotificationName:@"CallbackNotification" object:nil userInfo:userInfo];
 }
 
-#pragma mark - Protocol conformance
+#pragma mark - iZettleSDKAuthorizationProvider Protocol conformance
 
 - (void)authorizeAccountWithCompletion:(void (^)(iZettleSDKOAuthToken * _Nullable, NSError * _Nullable))completion {
     // Email can pre-filled in the login window
     UserAccountIdentifier *email = nil;
     NSArray *scopes = @[@"READ:USERINFO", @"READ:PAYMENT", @"WRITE:PAYMENT"];
-    [self getTokenWithAccountIdentifier:email scopes:scopes prompt:@"login" completionHandler:completion];
+    [self.tokenFetcher getTokenWithAccountIdentifier:email scopes:scopes prompt:@"login" completionHandler:completion];
 }
 
 - (void)verifyAccountWithUuid:(NSUUID * _Nonnull)uuid completion:(void (^ _Nonnull)(iZettleSDKOAuthToken * _Nullable, NSError * _Nullable))completion {
     // User UUID of the logged in account
     UserAccountIdentifier *userUUID = [[UserAccountIdentifier alloc] initWithUUID:uuid];
-    [self getTokenWithAccountIdentifier:userUUID scopes:@[@"WRITE:REFUND2"] prompt:@"verify" completionHandler:completion];
+    NSArray *scopes = @[@"WRITE:REFUND2"];
+    [self.tokenFetcher getTokenWithAccountIdentifier:userUUID scopes:scopes prompt:@"verify" completionHandler:completion];
 }
-
-#pragma mark - Authorizatoin
-
-- (void)getTokenWithAccountIdentifier:(UserAccountIdentifier *)identifier
-                               scopes:(NSArray<NSString *> *)scopes
-                               prompt:(NSString *)prompt
-                    completionHandler:(void (^ _Nonnull)(iZettleSDKOAuthToken *, NSError *))completion {
-    NSString *verifier = [self codeVerifier];
-    NSString *state = [NSUUID UUID].UUIDString;
-    NSURL *requestURL = [self authorizationURLWithScopes:scopes
-                                              promptType:prompt
-                                       accountIdentifier:identifier
-                                                verifier:verifier
-                                                   state:state];
-    
-    // Show login webview and recieve code in the callback
-    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:requestURL];
-    safari.delegate = self;
-    [UIApplication.sharedApplication.keyWindow.rootViewController presentViewController:safari animated:YES completion:nil];
-    
-    __weak CustomAuthorizationProvider *wSelf = self;
-    [self asyncAwaitSafariResponse:^(NSURL *callbackURL) {
-        [safari dismissViewControllerAnimated:YES completion:nil];
-        
-        // Cancelled by user
-        if (!callbackURL) {
-            completion(nil, [NSError errorWithDomain:@"login.domain" code:-1 userInfo:nil]);
-            return;
-        }
-        
-        NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:callbackURL resolvingAgainstBaseURL:NO];
-        NSArray *queryItems = urlComponents.queryItems;
-        BOOL validCallback = [queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == 'state' AND value == %@", state]].count;
-        NSURLQueryItem *codeItem = [queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == 'code'"]].firstObject;
-        
-        // Invalid callback url
-        if (!validCallback || !codeItem) {
-            completion(nil, [NSError errorWithDomain:@"login.domain" code:-1 userInfo:nil]);
-            return;
-        }
-        
-        [wSelf getTokenUsingCode:codeItem.value verifier:verifier completionHandler:completion];
-    }];
-    
-}
-
-/// Await response either from `ApplicationDelegate` or `SFSafariViewControllerDelegate`
-/// @discussion For iOS > 10 `SFAuthenticationSession` or `ASWebAuthenticationSession` should be used, they use `completionHandler`
-/// instead of relying on `application:openURL:options:` and `safariViewControllerDidFinish`.
-/// @param response Callback url containing session and code
-- (void)asyncAwaitSafariResponse:(void (^ _Nonnull)(NSURL  * _Nullable))response {
-    __weak NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
-    id __block observer = [NSNotificationCenter.defaultCenter addObserverForName:@"CallbackNotification"
-                                                                  object:nil
-                                                                   queue:nil
-                                                              usingBlock:^(NSNotification * _Nonnull note) {
-        response(note.userInfo[@"url"]);
-        [center removeObserver:observer];
-    }];
-}
-
-/// Exchange code from the callback for an iZettle OAuth token
-- (void)getTokenUsingCode:(NSString *)code verifier:(NSString *)verifier completionHandler:(void (^ _Nonnull)(iZettleSDKOAuthToken *, NSError *))completion{
-    NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:[self tokenURL]];
-    tokenRequest.HTTPBody = [self tokenBodyWithCode:code verifier:verifier];
-    tokenRequest.HTTPMethod = @"POST";
-    [tokenRequest addValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration: NSURLSessionConfiguration.defaultSessionConfiguration];
-    NSURLSessionDataTask *task = [session dataTaskWithRequest:tokenRequest
-                                            completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        if (!error) {
-            NSError *error;
-            iZettleSDKOAuthToken *token = [[iZettleSDKOAuthToken alloc] initWithData:data error:&error];
-            if (!error) {
-                completion(token, nil);
-            }
-            completion(nil, error);
-        } else {
-            completion(nil, error);
-        }
-    }];
-    [task resume];
-}
-
-#pragma mark - SFSafariViewControllerDelegate
-
-- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-    [CustomAuthorizationProvider notifySFSafariDidFinishWithCallbackURL:nil];
-}
-
-#pragma mark - PKCE
-// For more information visit:
-// https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce
-
-- (NSString *)codeVerifier {
-    NSMutableData *data = [NSMutableData dataWithLength:32];
-    int status = SecRandomCopyBytes(kSecRandomDefault, 32, data.mutableBytes);
-    if (status != errSecSuccess) {
-        // Handle error
-    }
-    return [[[[data base64EncodedStringWithOptions:0]
-              stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
-             stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
-            stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
-}
-
-- (NSString *)codeChallenge: (NSString *)verifier {
-    // You need to import CommonCrypto
-    u_int8_t buffer[CC_SHA256_DIGEST_LENGTH * sizeof(u_int8_t)];
-    memset(buffer, 0x0, CC_SHA256_DIGEST_LENGTH);
-    NSData *data = [verifier dataUsingEncoding:NSUTF8StringEncoding];
-    CC_SHA256([data bytes], (CC_LONG)[data length], buffer);
-    NSData *hash = [NSData dataWithBytes:buffer length:CC_SHA256_DIGEST_LENGTH];
-    return [[[[hash base64EncodedStringWithOptions:0]
-              stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
-             stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
-            stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
-}
-
-#pragma mark - URL
-
-- (NSURL *)authorizationURLWithScopes:(NSArray<NSString *>*)scopes
-                           promptType:(NSString *)prompt
-                    accountIdentifier:(UserAccountIdentifier *)accountIdentifier
-                             verifier:(NSString *)verifier
-                                state:(NSString *)state {
-    NSArray<NSURLQueryItem *> *queryItems = @[
-        [NSURLQueryItem queryItemWithName:@"client_id" value:self.clientId],
-        [NSURLQueryItem queryItemWithName:@"code_challenge" value:[self codeChallenge:verifier]],
-        [NSURLQueryItem queryItemWithName:@"code_challenge_method" value:@"S256"],
-        [NSURLQueryItem queryItemWithName:@"locale" value:@"en-GB"],
-        [NSURLQueryItem queryItemWithName:@"prompt" value:prompt],
-        [NSURLQueryItem queryItemWithName:@"redirect_uri" value:self.callback.absoluteString],
-        [NSURLQueryItem queryItemWithName:@"response_type" value:@"code"],
-        [NSURLQueryItem queryItemWithName:@"scope" value:[scopes componentsJoinedByString:@" "]],
-        [NSURLQueryItem queryItemWithName:@"state" value:state]
-    ];
-    
-    if (accountIdentifier.email.length) {
-        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"username"
-                                                                                 value:accountIdentifier.email]];
-    } else if (accountIdentifier.uuid) {
-        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"login_hint_type"
-                                                                                 value:@"uuid"]];
-        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"login_hint"
-                                                                                 value:accountIdentifier.uuid.UUIDString]];
-    }
-    
-    NSURLComponents *components = [[NSURLComponents alloc] initWithString:baseURL];
-    components.path = @"/authorize";
-    components.queryItems = queryItems;
-    
-    return [components URL];
-}
-
-- (NSURL *)tokenURL {
-    return [[NSURL URLWithString:baseURL] URLByAppendingPathComponent:@"token"];
-}
-
-- (NSData *)tokenBodyWithCode:(NSString *)code verifier:(NSString *)verifier{
-    NSURLComponents *queryComponents = [[NSURLComponents alloc] init];
-    queryComponents.queryItems = @[
-        [NSURLQueryItem queryItemWithName:@"code" value:code],
-        [NSURLQueryItem queryItemWithName:@"code_verifier" value:verifier],
-        [NSURLQueryItem queryItemWithName:@"client_id" value:self.clientId],
-        [NSURLQueryItem queryItemWithName:@"grant_type" value:@"authorization_code"],
-        [NSURLQueryItem queryItemWithName:@"redirect_uri" value:self.callback.absoluteString]
-    ];
-    
-    return [queryComponents.query dataUsingEncoding:NSUTF8StringEncoding];
-}
-
 @end

--- a/Example/Sample/iZettleSDKSample/Helpers/AccessTokenFetcher.h
+++ b/Example/Sample/iZettleSDKSample/Helpers/AccessTokenFetcher.h
@@ -1,0 +1,34 @@
+//
+//  AccessTokenFetcher.h
+//  iZettle SDK Sample
+//
+//  Copyright © 2021 PayPal Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@import SafariServices;
+@import iZettleSDK;
+
+NS_ASSUME_NONNULL_BEGIN
+@interface UserAccountIdentifier: NSObject
+
+@property(nullable, strong, nonatomic, readonly) NSString *email;
+@property(nullable, strong, nonatomic, readonly) NSUUID *uuid;
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithUUID:(NSUUID *)uuid;
+
+@end
+
+@interface AccessTokenFetcher : NSObject <SFSafariViewControllerDelegate>
+@property (nonatomic, copy) void (^safariViewControllerDidFinish)(void);
+- (instancetype)initWith:(NSString *)clientId callbackUrl:(NSURL *)callbackUrl;
+- (void)getTokenWithAccountIdentifier:(UserAccountIdentifier *)identifier
+                               scopes:(NSArray<NSString *> *)scopes
+                               prompt:(NSString *)prompt
+                    completionHandler:(void (^ _Nonnull)(iZettleSDKOAuthToken *, NSError *))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Sample/iZettleSDKSample/Helpers/AccessTokenFetcher.m
+++ b/Example/Sample/iZettleSDKSample/Helpers/AccessTokenFetcher.m
@@ -1,0 +1,218 @@
+//
+//  AccessTokenFetcher.m
+//  iZettle SDK Sample
+//
+//  Copyright © 2021 PayPal Inc. All rights reserved.
+//
+
+#import "AccessTokenFetcher.h"
+@import CommonCrypto;
+@import iZettleSDK;
+
+static NSString *baseURL = @"https://oauth.izettle.com";
+
+#pragma mark - UserAccountIdentifier
+
+@implementation UserAccountIdentifier
+
+- (instancetype)initWithEmail:(NSString *)email {
+    if ([super init]) {
+        _email = email;
+    }
+    return self;
+}
+
+- (instancetype)initWithUUID:(NSUUID *)uuid {
+    if ([super init]) {
+        _uuid = uuid;
+    }
+    return self;
+}
+@end
+
+@interface AccessTokenFetcher()
+@property(nonatomic)NSString *clientId;
+@property(nonatomic)NSURL *callback;
+@end
+
+@implementation AccessTokenFetcher
+
+- (instancetype)initWith:(NSString *)clientId callbackUrl:(NSURL *)callbackUrl {
+    if (self = [super init]) {
+        self.clientId = clientId;
+        self.callback = callbackUrl;
+    }
+    return self;
+}
+
+- (void)getTokenWithAccountIdentifier:(UserAccountIdentifier *)identifier
+                               scopes:(NSArray<NSString *> *)scopes
+                               prompt:(NSString *)prompt
+                    completionHandler:(void (^ _Nonnull)(iZettleSDKOAuthToken *, NSError *))completion {
+    NSString *verifier = [self codeVerifier];
+    NSString *state = [NSUUID UUID].UUIDString;
+    NSURL *requestURL = [self authorizationURLWithScopes:scopes
+                                              promptType:prompt
+                                       accountIdentifier:identifier
+                                                verifier:verifier
+                                                   state:state];
+    
+    // Show login webview and recieve code in the callback
+    SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:requestURL];
+    safari.delegate = self;
+    [UIApplication.sharedApplication.keyWindow.rootViewController presentViewController:safari animated:YES completion:nil];
+    
+    __weak AccessTokenFetcher *wSelf = self;
+    [self asyncAwaitSafariResponse:^(NSURL *callbackURL) {
+        [safari dismissViewControllerAnimated:YES completion:nil];
+        
+        // Cancelled by user
+        if (!callbackURL) {
+            completion(nil, [NSError errorWithDomain:@"login.domain" code:-1 userInfo:nil]);
+            return;
+        }
+        
+        NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:callbackURL resolvingAgainstBaseURL:NO];
+        NSArray *queryItems = urlComponents.queryItems;
+        BOOL validCallback = [queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == 'state' AND value == %@", state]].count;
+        NSURLQueryItem *codeItem = [queryItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == 'code'"]].firstObject;
+        
+        // Invalid callback url
+        if (!validCallback || !codeItem) {
+            completion(nil, [NSError errorWithDomain:@"login.domain" code:-1 userInfo:nil]);
+            return;
+        }
+        
+        [wSelf getTokenUsingCode:codeItem.value verifier:verifier completionHandler:completion];
+    }];
+    
+}
+
+/// Await response either from `ApplicationDelegate` or `SFSafariViewControllerDelegate`
+/// @discussion For iOS > 10 `SFAuthenticationSession` or `ASWebAuthenticationSession` should be used, they use `completionHandler`
+/// instead of relying on `application:openURL:options:` and `safariViewControllerDidFinish`.
+/// @param response Callback url containing session and code
+- (void)asyncAwaitSafariResponse:(void (^ _Nonnull)(NSURL  * _Nullable))response {
+    __weak NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    id __block observer = [NSNotificationCenter.defaultCenter addObserverForName:@"CallbackNotification"
+                                                                  object:nil
+                                                                   queue:nil
+                                                              usingBlock:^(NSNotification * _Nonnull note) {
+        response(note.userInfo[@"url"]);
+        [center removeObserver:observer];
+    }];
+}
+
+/// Exchange code from the callback for an iZettle OAuth token
+- (void)getTokenUsingCode:(NSString *)code verifier:(NSString *)verifier completionHandler:(void (^ _Nonnull)(iZettleSDKOAuthToken *, NSError *))completion{
+    NSMutableURLRequest *tokenRequest = [NSMutableURLRequest requestWithURL:[self tokenURL]];
+    tokenRequest.HTTPBody = [self tokenBodyWithCode:code verifier:verifier];
+    tokenRequest.HTTPMethod = @"POST";
+    [tokenRequest addValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration: NSURLSessionConfiguration.defaultSessionConfiguration];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:tokenRequest
+                                            completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (!error) {
+            NSError *error;
+            iZettleSDKOAuthToken *token = [[iZettleSDKOAuthToken alloc] initWithData:data error:&error];
+            if (!error) {
+                completion(token, nil);
+                return;
+            }
+            completion(nil, error);
+        } else {
+            completion(nil, error);
+        }
+    }];
+    [task resume];
+}
+
+#pragma mark - SFSafariViewControllerDelegate
+
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
+    self.safariViewControllerDidFinish();
+}
+
+#pragma mark - PKCE
+// For more information visit:
+// https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce
+
+- (NSString *)codeVerifier {
+    NSMutableData *data = [NSMutableData dataWithLength:32];
+    int status = SecRandomCopyBytes(kSecRandomDefault, 32, data.mutableBytes);
+    if (status != errSecSuccess) {
+        // Handle error
+    }
+    return [[[[data base64EncodedStringWithOptions:0]
+              stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
+             stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
+            stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
+}
+
+- (NSString *)codeChallenge: (NSString *)verifier {
+    // You need to import CommonCrypto
+    u_int8_t buffer[CC_SHA256_DIGEST_LENGTH * sizeof(u_int8_t)];
+    memset(buffer, 0x0, CC_SHA256_DIGEST_LENGTH);
+    NSData *data = [verifier dataUsingEncoding:NSUTF8StringEncoding];
+    CC_SHA256([data bytes], (CC_LONG)[data length], buffer);
+    NSData *hash = [NSData dataWithBytes:buffer length:CC_SHA256_DIGEST_LENGTH];
+    return [[[[hash base64EncodedStringWithOptions:0]
+              stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
+             stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
+            stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"="]];
+}
+
+#pragma mark - URL
+
+- (NSURL *)authorizationURLWithScopes:(NSArray<NSString *>*)scopes
+                           promptType:(NSString *)prompt
+                    accountIdentifier:(UserAccountIdentifier *)accountIdentifier
+                             verifier:(NSString *)verifier
+                                state:(NSString *)state {
+    NSArray<NSURLQueryItem *> *queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"client_id" value:self.clientId],
+        [NSURLQueryItem queryItemWithName:@"code_challenge" value:[self codeChallenge:verifier]],
+        [NSURLQueryItem queryItemWithName:@"code_challenge_method" value:@"S256"],
+        [NSURLQueryItem queryItemWithName:@"locale" value:@"en-GB"],
+        [NSURLQueryItem queryItemWithName:@"prompt" value:prompt],
+        [NSURLQueryItem queryItemWithName:@"redirect_uri" value:self.callback.absoluteString],
+        [NSURLQueryItem queryItemWithName:@"response_type" value:@"code"],
+        [NSURLQueryItem queryItemWithName:@"scope" value:[scopes componentsJoinedByString:@" "]],
+        [NSURLQueryItem queryItemWithName:@"state" value:state]
+    ];
+    
+    if (accountIdentifier.email.length) {
+        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"username"
+                                                                                 value:accountIdentifier.email]];
+    } else if (accountIdentifier.uuid) {
+        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"login_hint_type"
+                                                                                 value:@"uuid"]];
+        queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"login_hint"
+                                                                                 value:accountIdentifier.uuid.UUIDString]];
+    }
+    
+    NSURLComponents *components = [[NSURLComponents alloc] initWithString:baseURL];
+    components.path = @"/authorize";
+    components.queryItems = queryItems;
+    
+    return [components URL];
+}
+
+- (NSURL *)tokenURL {
+    return [[NSURL URLWithString:baseURL] URLByAppendingPathComponent:@"token"];
+}
+
+- (NSData *)tokenBodyWithCode:(NSString *)code verifier:(NSString *)verifier{
+    NSURLComponents *queryComponents = [[NSURLComponents alloc] init];
+    queryComponents.queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"code" value:code],
+        [NSURLQueryItem queryItemWithName:@"code_verifier" value:verifier],
+        [NSURLQueryItem queryItemWithName:@"client_id" value:self.clientId],
+        [NSURLQueryItem queryItemWithName:@"grant_type" value:@"authorization_code"],
+        [NSURLQueryItem queryItemWithName:@"redirect_uri" value:self.callback.absoluteString]
+    ];
+    
+    return [queryComponents.query dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@end


### PR DESCRIPTION
Moved auth token fetching code into a helper class to simplify the example of the protocol implementation of the auth provider. 