### PR TITLE
Fixed broken link to custom auth example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ class YourCustomAuthClass: iZettleSDKAuthorizationProvider {
 }
 ```
 
-See also this custom authorization provider [sample](https://github.com/iZettle/sdk-ios/blob/master/Example/Sample/iZettleSDKSample/CustomAuthorizationProvider.m).
+See also this custom authorization provider [example](https://github.com/iZettle/sdk-ios/blob/master/Example/iZettleSDKSample/CustomAuthorizationProvider.m).
 
 ## SDK Operations
 


### PR DESCRIPTION
The link to the sample project is broken. The link text should be changed to "example" 
and point to this URL https://github.com/iZettle/sdk-ios/blob/master/Example/iZettleSDKSample/CustomAuthorizationProvider.m