### PR TITLE
Remove deprecated reader EA protocol from sample

### DIFF
--- a/Example/iZettleSDKSample/Info.plist
+++ b/Example/iZettleSDKSample/Info.plist
@@ -58,7 +58,6 @@
 	</array>
 	<key>UISupportedExternalAccessoryProtocols</key>
 	<array>
-		<string>com.miura.shuttle.izettle</string>
 		<string>com.izettle.cardreader-one</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
We deprecated this reader a few years ago. Removing it from the sample app so that integrators don't copy it by mistake to their projects. Doing so will result in a request from Apple to provide MFi enrolment information during app review process.