### PR TITLE
Update SDK name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "sdk-ios",
+    name: "izettle-sdk-ios",
     platforms: [
         .iOS(.v12)
     ],


### PR DESCRIPTION
This is a proposal to improve the naming of this package in SPM dependency tree.

Right now this is how it looks like:

<img width="277" height="79" alt="image" src="https://github.com/user-attachments/assets/68f3974f-cf44-4ee4-b304-1e5c76cdf612" />

By prefixing with "izettle" it will be easier to know the origin of this package and helping to find which version we are on.